### PR TITLE
Fix HTML markup and CSS typo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2172,7 +2172,7 @@ p, ul, ol {
     width: 80vw;
     height: 80vw;
   }
-  #part-worksSingle header .hero-pic phone img {
+  #part-worksSingle header .hero-pic.phone img {
     height: 105%;
   }
   #part-worksSingle header .hero-scroll {

--- a/works/projects.html
+++ b/works/projects.html
@@ -226,7 +226,7 @@
         </div>
         <div class="flex-stack-image">
           <a href="https://github.com/fablabsd/MakerPass-Backend" target="_blank">
-            <span><img src=""><span>
+            <span><img src="" /></span>
           </a>
         </div>
       </div>

--- a/works/testing.html
+++ b/works/testing.html
@@ -135,8 +135,8 @@
 
   	<div class="titles">
   		<h1><span><img src="../assets/medias/works/robo/robo-logo.png" /></span></h1>
-    </br>
-    </br>
+    <br/>
+    <br/>
       <h2><span>Extensively Tested</span></h2>
   	</div>
 
@@ -154,8 +154,8 @@
   		<p class="title">Tested to UL, CE, & FCC standards.</p>
   		<p class="text">I led the regulatory compliance testing on the R2 and C2 lines of printers with partners Nemko and UL.  CE testing allowed for sale in EU countries, while UL was required
         for Australia and Canada.  All pre-testing was completed myself at Nemko in Carlsbad, CA prior to official compliance testing.
-      </br>
-      </br>
+      <br/>
+      <br/>
       All testing was completed to Class A limits for CISPER 32 and FCC 47 CFR Part 15, as well as within and exceeding LPS limits for UL.</p>
 		<ul>
 			<li><strong>Team</strong>Robo 3D </li>
@@ -176,9 +176,9 @@
 
     <div class="row">
     <center>
-      <div class="columns-list"><img src="http://static1.squarespace.com/static/56feae0ab6aa60ebb6039bf3/56feb2c074e8d6373306a533/56feb48c74e8d6373306dbd7/1503504407658/?format=1500w" height="200"></a></div>
-      <div class="columns-list"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/FCC_New_Logo.svg/200px-FCC_New_Logo.svg.png" height="200"></a></div>
-      <div class="columns-list"><img src="https://ec.europa.eu/growth/sites/growth/files/ce-mark.png" height="165"></a></div>
+      <div class="columns-list"><img src="http://static1.squarespace.com/static/56feae0ab6aa60ebb6039bf3/56feb2c074e8d6373306a533/56feb48c74e8d6373306dbd7/1503504407658/?format=1500w" height="200"></div>
+      <div class="columns-list"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/FCC_New_Logo.svg/200px-FCC_New_Logo.svg.png" height="200"></div>
+      <div class="columns-list"><img src="https://ec.europa.eu/growth/sites/growth/files/ce-mark.png" height="165"></div>
     </div>
     <p style="padding: 7em 0 0 0;"></p>
 


### PR DESCRIPTION
## Summary
- fix CSS typo for hero-pic phone selector
- correct invalid HTML tags in testing and projects pages

## Testing
- `htmlhint $(find . -name '*.html')`

------
https://chatgpt.com/codex/tasks/task_e_685f8182064c83218996720dc6deeaff