### PR TITLE
Use external images for AgilePod page

### DIFF
--- a/works/agilepod.html
+++ b/works/agilepod.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="agilepod.html" />
+  <title>Allen McAfee - B-52 AgilePod Demo</title>
+  <link href='https://fonts.googleapis.com/css?family=Work+Sans:400,300,500' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" type="text/css" href="../assets/css/style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="B-52 AgilePod Demo" />
+  <meta property="og:url" content="agilepod.html" />
+  <meta property="og:image" content="https://theaviationist.com/wp-content/uploads/2023/06/AgilePod-top.jpg" />
+  <meta property="og:site_name" content="Allen McAfee" />
+  <meta property="og:description" content="Summary of B-52 AgilePod communication upgrade testing." />
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="B-52 AgilePod Demo" />
+  <meta name="twitter:description" content="Summary of B-52 AgilePod communication upgrade testing." />
+  <meta name="twitter:image:src" content="https://theaviationist.com/wp-content/uploads/2023/06/AgilePod-top.jpg" />
+</head>
+<body>
+  <header class="main-header popin-header">
+    <a class="main-logo" href="/">
+      <div id="amlogosvg"></div>
+    </a>
+    <p>The works of <a href="http://github.com/allenmcafee" target="_blank">@allenmcafee</a></p>
+  </header>
+
+  <div class="ajax-container" id="part-worksSingle">
+    <a href="/" class="button-next">
+      <span></span>
+      <p><strong>Back to home</strong></p>
+    </a>
+
+    <header>
+      <div class="titles">
+        <h1><span>B-52 AgilePod Demo</span></h1>
+        <h2><span>Expanding communications for the Stratofortress</span></h2>
+      </div>
+      <div class="hero-container">
+        <div class="background-pic">
+          <img src="https://theaviationist.com/wp-content/uploads/2023/06/AgilePod-top.jpg" class="background" />
+        </div>
+        <div class="hero-pic">
+          <img src="https://theaviationist.com/wp-content/uploads/2023/06/B-52-Agile-Pod-706x394.jpeg" class="hero" />
+        </div>
+      </div>
+    </header>
+
+    <section class="presentation">
+      <p class="text">
+        The U.S. Air Force is testing a new <strong>AgilePod</strong> on the B-52 Stratofortress as part of its ongoing modernization program. The modular pod is designed to quickly integrate advanced communications equipment across multiple domains and provide rapid solutions to emerging threats.
+      </p>
+      <p class="text">
+        Officials describe the AgilePod as a "Swiss-Army Knife" for aircraft, able to host different payloads within its open architecture. The recent demonstrations with the 49th Test and Evaluation Squadron have included both ground and flight tests to verify operational capability.
+      </p>
+      <p class="text">
+        By using a standardized, multi-mission pod, the service can field new technology much faster than traditional modification programs. Future versions may add capabilities such as AI algorithms or LiDAR sensors, keeping the venerable B-52 relevant for decades to come.
+      </p>
+    </section>
+
+    <section class="medias">
+      <img src="https://theaviationist.com/wp-content/uploads/2023/06/AgilePod-side-706x376.jpeg" />
+      <img src="https://theaviationist.com/wp-content/uploads/2023/06/AgilePod-top.jpg" />
+      <div class="line"></div>
+    </section>
+  </div>
+
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+  <script type="text/javascript" src="../assets/js/scripts.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove binary images for AgilePod article
- reference the original article's images directly

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687738506cb4832191740ac0132b6a56