### PR TITLE
chore: remove redundant jquery cdn

### DIFF
--- a/assets/fonts/gt-walsheim-light-web-2.html
+++ b/assets/fonts/gt-walsheim-light-web-2.html
@@ -198,7 +198,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web-3.html
+++ b/assets/fonts/gt-walsheim-light-web-3.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web-4.html
+++ b/assets/fonts/gt-walsheim-light-web-4.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web.html
+++ b/assets/fonts/gt-walsheim-light-web.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-webd41d.html
+++ b/assets/fonts/gt-walsheim-light-webd41d.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-2.html
+++ b/assets/fonts/gt-walsheim-medium-web-2.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-3.html
+++ b/assets/fonts/gt-walsheim-medium-web-3.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-4.html
+++ b/assets/fonts/gt-walsheim-medium-web-4.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web.html
+++ b/assets/fonts/gt-walsheim-medium-web.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-webd41d.html
+++ b/assets/fonts/gt-walsheim-medium-webd41d.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-2.html
+++ b/assets/fonts/gt-walsheim-regular-web-2.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-3.html
+++ b/assets/fonts/gt-walsheim-regular-web-3.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-4.html
+++ b/assets/fonts/gt-walsheim-regular-web-4.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web.html
+++ b/assets/fonts/gt-walsheim-regular-web.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-webd41d.html
+++ b/assets/fonts/gt-walsheim-regular-webd41d.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-2.html
+++ b/assets/fonts/noedisplay-medium-2.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-3.html
+++ b/assets/fonts/noedisplay-medium-3.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-4.html
+++ b/assets/fonts/noedisplay-medium-4.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium.html
+++ b/assets/fonts/noedisplay-medium.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-mediumd41d.html
+++ b/assets/fonts/noedisplay-mediumd41d.html
@@ -189,7 +189,6 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -387,7 +387,6 @@
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="assets/js/scripts.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/delta.html
+++ b/works/delta.html
@@ -272,7 +272,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/electronics.html
+++ b/works/electronics.html
@@ -283,7 +283,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/industrial.html
+++ b/works/industrial.html
@@ -263,7 +263,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/paper.html
+++ b/works/paper.html
@@ -262,7 +262,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/projects.html
+++ b/works/projects.html
@@ -323,7 +323,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/robo.html
+++ b/works/robo.html
@@ -452,7 +452,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/roboapp.html
+++ b/works/roboapp.html
@@ -301,7 +301,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/sandbox.html
+++ b/works/sandbox.html
@@ -270,7 +270,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/spoon.html
+++ b/works/spoon.html
@@ -261,7 +261,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/testing.html
+++ b/works/testing.html
@@ -278,7 +278,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/ux.html
+++ b/works/ux.html
@@ -269,7 +269,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/viz.html
+++ b/works/viz.html
@@ -269,7 +269,6 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
 <script type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- remove duplicate jQuery CDN script from all pages since jQuery is already bundled in scripts.js

## Testing
- `npm test` *(fails: ENOENT package.json)*