### PR TITLE
perf: defer script loading

### DIFF
--- a/assets/fonts/gt-walsheim-light-web-2.html
+++ b/assets/fonts/gt-walsheim-light-web-2.html
@@ -73,7 +73,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -195,10 +195,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web-3.html
+++ b/assets/fonts/gt-walsheim-light-web-3.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web-4.html
+++ b/assets/fonts/gt-walsheim-light-web-4.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-web.html
+++ b/assets/fonts/gt-walsheim-light-web.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-light-webd41d.html
+++ b/assets/fonts/gt-walsheim-light-webd41d.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-2.html
+++ b/assets/fonts/gt-walsheim-medium-web-2.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-3.html
+++ b/assets/fonts/gt-walsheim-medium-web-3.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web-4.html
+++ b/assets/fonts/gt-walsheim-medium-web-4.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-web.html
+++ b/assets/fonts/gt-walsheim-medium-web.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-medium-webd41d.html
+++ b/assets/fonts/gt-walsheim-medium-webd41d.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-2.html
+++ b/assets/fonts/gt-walsheim-regular-web-2.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-3.html
+++ b/assets/fonts/gt-walsheim-regular-web-3.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web-4.html
+++ b/assets/fonts/gt-walsheim-regular-web-4.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-web.html
+++ b/assets/fonts/gt-walsheim-regular-web.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/gt-walsheim-regular-webd41d.html
+++ b/assets/fonts/gt-walsheim-regular-webd41d.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-2.html
+++ b/assets/fonts/noedisplay-medium-2.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-3.html
+++ b/assets/fonts/noedisplay-medium-3.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium-4.html
+++ b/assets/fonts/noedisplay-medium-4.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-medium.html
+++ b/assets/fonts/noedisplay-medium.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/assets/fonts/noedisplay-mediumd41d.html
+++ b/assets/fonts/noedisplay-mediumd41d.html
@@ -63,7 +63,7 @@
 
 </head>
 <body>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -186,10 +186,9 @@
 
 </script>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="/assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="/assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -385,9 +385,8 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="assets/js/scripts.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/works/delta.html
+++ b/works/delta.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -269,10 +269,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/electronics.html
+++ b/works/electronics.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -280,10 +280,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/industrial.html
+++ b/works/industrial.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -260,10 +260,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/paper.html
+++ b/works/paper.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -259,10 +259,9 @@
 </section>
 
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/projects.html
+++ b/works/projects.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -320,10 +320,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/robo.html
+++ b/works/robo.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -449,10 +449,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/roboapp.html
+++ b/works/roboapp.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -298,10 +298,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/sandbox.html
+++ b/works/sandbox.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -267,10 +267,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/spoon.html
+++ b/works/spoon.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -258,10 +258,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/testing.html
+++ b/works/testing.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -275,10 +275,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/ux.html
+++ b/works/ux.html
@@ -72,7 +72,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -266,10 +266,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 

--- a/works/viz.html
+++ b/works/viz.html
@@ -74,7 +74,7 @@
 
 </head>
 <body>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   <div id="init-page"></div>
 
   <header class="main-header popin-header">
@@ -266,10 +266,9 @@
 
 </section>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
-<script type="text/javascript" src="../assets/js/scripts.js"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js"></script>
+<script defer type="text/javascript" src="../assets/js/scripts.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- defer ScrollMagic, TweenMax, and site scripts across pages to avoid blocking render

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981b38e504832192b8aebd4eafa472